### PR TITLE
feat(): Add spread operator to param options in subscribeAll function

### DIFF
--- a/packages/eventsub/src/structures/EventSubConnection.ts
+++ b/packages/eventsub/src/structures/EventSubConnection.ts
@@ -76,7 +76,7 @@ export class EventSubConnection extends EventSubEventEmitter{
 
   }
 
-  public async subscribeAll<T extends SubscriptionTypes>(options: SubscriptionOptionsIndex[T][]): Promise<Subscription<T>[]>{
+  public async subscribeAll<T extends SubscriptionTypes>(...options: SubscriptionOptionsIndex[T][]): Promise<Subscription<T>[]>{
 
     const subscriptions: Subscription<SubscriptionTypes>[] = [];
 


### PR DESCRIPTION
Add spread operator to `EventSubConnection.subscribeAll(...options)` options.