### PR TITLE
chore(): Bump to 1.3.6!

### DIFF
--- a/packages/helix/package.json
+++ b/packages/helix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twitchapi/helix",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "A powerful node module to interact with twitch api",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
`@twitchapi/helix` bumped to 1.3.6!