### PR TITLE
fix(): Fix maintainedSubscription between connections bug

### DIFF
--- a/packages/eventsub/src/webhook/structures/WebhookConnection.ts
+++ b/packages/eventsub/src/webhook/structures/WebhookConnection.ts
@@ -128,6 +128,8 @@ export class WebhookConnection extends EventSubEventEmitter<WebhookConnection>{
     if(this.mantainSubscriptions) {
 
       for(const data of subscriptions){
+
+        if((data.transport as { callback: string }).callback !== this.baseURL + this.subscriptionRoute) continue;
       
         const subscription = new Subscription<SubscriptionTypes, WebhookConnection>(this, { type: data.type as SubscriptionTypes, auth: this.auth, options: data.condition as any }, data);
 


### PR DESCRIPTION
# MINOR CHANGES

Fixed a bug which made the subscriptions without the connection callback to be added as simple subscriptions when option `maintainSubscriptions` is set to true.