### PR TITLE
fix(): Fix types for message param in SubscriptionMessage event

### DIFF
--- a/packages/eventsub/src/interfaces/EventSubEvents.ts
+++ b/packages/eventsub/src/interfaces/EventSubEvents.ts
@@ -5,5 +5,5 @@ import type { SubscriptionTypes } from '../enums';
 export interface EventSubEvents<K extends ConnectionTypes = ConnectionTypes> {
     connectionReady: (...args: [connection: K]) => void,
     subscriptionCreate: (...args: [subscription: Subscription<SubscriptionTypes, K>]) => void,
-    subscriptionMessage: (...args: [message: SubscriptionMessage, subscription: Subscription<SubscriptionTypes, K>]) => void
+    subscriptionMessage: (...args: [message: SubscriptionMessage<K>, subscription: Subscription<SubscriptionTypes, K>]) => void
 }


### PR DESCRIPTION
# BUG FIXES 🐛

* Fixed a bug which prevented to get right types of param `message` in SubscriptionMessage event as it was typed with default connection and not with the type of connection that was invoking the listener.